### PR TITLE
Options

### DIFF
--- a/internal/messages/error_message.go
+++ b/internal/messages/error_message.go
@@ -1,0 +1,43 @@
+package messages
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const errorMsgIdentifierKey = "b58c8bae78504da3a2e32cceeb77d342"
+
+var jsonErrorMsgPrefix string
+
+func init() {
+	jsonErrorMsgPrefix = fmt.Sprintf("{\n\t\"identifier\": \"%s\",", errorMsgIdentifierKey)
+}
+
+type ErrorMsg struct {
+	Identifier   string        `json:"identifier"` // used to identify an error message from other types of messages
+	Error        string        `json:"error"`
+	ReferenceMsg *ReferenceMsg `json:"reference_msg"`
+}
+
+func NewErrorMsg(err error, refMsg *ReferenceMsg) *ErrorMsg {
+	return &ErrorMsg{
+		Identifier:   errorMsgIdentifierKey,
+		Error:        err.Error(),
+		ReferenceMsg: refMsg,
+	}
+}
+
+func (msg *ErrorMsg) ToJson() ([]byte, error) {
+	return json.MarshalIndent(msg, "", "\t")
+}
+
+func ToErrorMsg(msg string) (*ErrorMsg, error) {
+	var errMsg ErrorMsg
+	err := json.Unmarshal([]byte(msg), &errMsg)
+	return &errMsg, err
+}
+
+func IsErrorMsg(msg string) bool {
+	return strings.HasPrefix(msg, jsonErrorMsgPrefix)
+}

--- a/internal/messages/error_message_test.go
+++ b/internal/messages/error_message_test.go
@@ -1,0 +1,41 @@
+package messages
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrorMessageSerialization(t *testing.T) {
+	expected := `{
+	"identifier": "%s",
+	"error": "testErrorVal",
+	"reference_msg": {
+		"identifier": "%s",
+		"s3_region": "testS3RegionVal",
+		"s3_bucket": "testS3BucketVal",
+		"s3_key": "testS3KeyVal",
+		"md5_digest_msg_body": "testMd5BodyVal",
+		"md5_digest_msg_attr": "testMd5AttrVal"
+	}
+}`
+	expected = fmt.Sprintf(expected, errorMsgIdentifierKey, referenceMsgIdentifierKey)
+	testRefMsg := NewReferenceMsg("testS3RegionVal", "testS3BucketVal", "testS3KeyVal", "testMd5BodyVal", "testMd5AttrVal")
+	testErrMsg := NewErrorMsg(errors.New("testErrorVal"), testRefMsg)
+
+	// test ToJson
+	j, err := testErrMsg.ToJson()
+	assert.Nil(t, err, "error should be nil when calling ToJson")
+	assert.Equal(t, expected, string(j))
+
+	// test IsErrorMessage
+	assert.True(t, IsErrorMsg(string(j)))
+	assert.False(t, IsErrorMsg("foo"))
+
+	// test ToErrorMsg
+	errMsg2, err := ToErrorMsg(string(j))
+	assert.Nil(t, err, "error should be nil when calling ToErrorMsg")
+	assert.Equal(t, testErrMsg, errMsg2)
+}

--- a/options.go
+++ b/options.go
@@ -1,7 +1,7 @@
 package hefty
 
 type options struct {
-	alwaysSendToS3 *bool
+	alwaysSendToS3 bool
 }
 
 type Option func(opts *options) error
@@ -10,8 +10,7 @@ type Option func(opts *options) error
 // If selected, the message payload will always be sent to AWS S3 regardless of its size
 func AlwaysSendToS3() Option {
 	return func(opts *options) error {
-		send := true
-		opts.alwaysSendToS3 = &send
+		opts.alwaysSendToS3 = true
 		return nil
 	}
 }

--- a/options.go
+++ b/options.go
@@ -6,7 +6,6 @@ type options struct {
 
 type Option func(opts *options) error
 
-// TODO: Need to add tests for this option
 // If selected, the message payload will always be sent to AWS S3 regardless of its size
 func AlwaysSendToS3() Option {
 	return func(opts *options) error {

--- a/options.go
+++ b/options.go
@@ -1,0 +1,17 @@
+package hefty
+
+type options struct {
+	alwaysSendToS3 *bool
+}
+
+type Option func(opts *options) error
+
+// TODO: Need to add tests for this option
+// If selected, the message payload will always be sent to AWS S3 regardless of its size
+func AlwaysSendToS3() Option {
+	return func(opts *options) error {
+		send := true
+		opts.alwaysSendToS3 = &send
+		return nil
+	}
+}

--- a/sns.go
+++ b/sns.go
@@ -55,9 +55,7 @@ func NewSnsClientWrapper(snsClient *sns.Client, s3Client *s3.Client, bucketName 
 			return nil, err
 		}
 	}
-	if wrapperOptions.alwaysSendToS3 != nil {
-		wrapper.alwaysSendToS3 = *wrapperOptions.alwaysSendToS3
-	}
+	wrapper.alwaysSendToS3 = wrapperOptions.alwaysSendToS3
 
 	return wrapper, nil
 }

--- a/sns.go
+++ b/sns.go
@@ -18,17 +18,18 @@ import (
 
 type SnsClientWrapper struct {
 	sns.Client
-	bucket     string
-	s3Client   *s3.Client
-	uploader   *s3manager.Uploader
-	downloader *s3manager.Downloader
+	bucket         string
+	s3Client       *s3.Client
+	uploader       *s3manager.Uploader
+	downloader     *s3manager.Downloader
+	alwaysSendToS3 bool
 }
 
 // NewSnsClientWrapper will create a new Hefty SNS client wrapper using an existing AWS SNS client and AWS S3 client.
 // This Hefty SNS client wrapper will save large messages greater than MaxSqsSnsMessageLengthBytes to AWS S3 in the
 // bucket that is specified via `bucketName`. The S3 client should have the ability of reading and writing to this bucket.
 // This function will also check if the bucket exists and is accessible.
-func NewSnsClientWrapper(snsClient *sns.Client, s3Client *s3.Client, bucketName string) (*SnsClientWrapper, error) {
+func NewSnsClientWrapper(snsClient *sns.Client, s3Client *s3.Client, bucketName string, opts ...Option) (*SnsClientWrapper, error) {
 	// check if bucket exits
 	if ok, err := utils.BucketExists(s3Client, bucketName); !ok {
 		if err != nil {
@@ -38,13 +39,27 @@ func NewSnsClientWrapper(snsClient *sns.Client, s3Client *s3.Client, bucketName 
 		return nil, fmt.Errorf("bucket %s does not exist or is not accessible", bucketName)
 	}
 
-	return &SnsClientWrapper{
+	wrapper := &SnsClientWrapper{
 		Client:     *snsClient,
 		bucket:     bucketName,
 		s3Client:   s3Client,
 		uploader:   s3manager.NewUploader(s3Client),
 		downloader: s3manager.NewDownloader(s3Client),
-	}, nil
+	}
+
+	// process available options
+	var wrapperOptions options
+	for _, opt := range opts {
+		err := opt(&wrapperOptions)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if wrapperOptions.alwaysSendToS3 != nil {
+		wrapper.alwaysSendToS3 = *wrapperOptions.alwaysSendToS3
+	}
+
+	return wrapper, nil
 }
 
 // PublishHeftyMessage will calculate the messages size from `params` and determine if the MaxSqsSnsMessageLengthBytes is exceeded.
@@ -58,13 +73,13 @@ func NewSnsClientWrapper(snsClient *sns.Client, s3Client *s3.Client, bucketName 
 // hefty client.
 //
 // Note that this function's signature matches that of the AWS SNS SDK's Publish method.
-func (client *SnsClientWrapper) PublishHeftyMessage(ctx context.Context, params *sns.PublishInput, optFns ...func(*sns.Options)) (*sns.PublishOutput, error) {
+func (wrapper *SnsClientWrapper) PublishHeftyMessage(ctx context.Context, params *sns.PublishInput, optFns ...func(*sns.Options)) (*sns.PublishOutput, error) {
 	// input validation; if invalid input let AWS SDK handle it
 	if params == nil ||
 		params.Message == nil ||
 		len(*params.Message) == 0 {
 
-		return client.Publish(ctx, params, optFns...)
+		return wrapper.Publish(ctx, params, optFns...)
 	}
 
 	// normalize message attributes
@@ -77,8 +92,8 @@ func (client *SnsClientWrapper) PublishHeftyMessage(ctx context.Context, params 
 	}
 
 	// validate message size
-	if msgSize <= MaxAwsMessageLengthBytes {
-		return client.Publish(ctx, params, optFns...)
+	if !wrapper.alwaysSendToS3 && msgSize <= MaxAwsMessageLengthBytes {
+		return wrapper.Publish(ctx, params, optFns...)
 	} else if msgSize > MaxHeftyMessageLengthBytes {
 		return nil, fmt.Errorf("message size of %d bytes greater than allowed message size of %d bytes", msgSize, MaxHeftyMessageLengthBytes)
 	}
@@ -98,14 +113,14 @@ func (client *SnsClientWrapper) PublishHeftyMessage(ctx context.Context, params 
 	}
 
 	// create reference message
-	refMsg, err := newSnsReferenceMessage(params.TopicArn, client.bucket, client.Options().Region, msgBodyHash, msgAttrHash)
+	refMsg, err := newSnsReferenceMessage(params.TopicArn, wrapper.bucket, wrapper.Options().Region, msgBodyHash, msgAttrHash)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create reference message from topicArn. %v", err)
 	}
 
 	// upload hefty message to s3
-	_, err = client.uploader.Upload(ctx, &s3.PutObjectInput{
-		Bucket: aws.String(client.bucket),
+	_, err = wrapper.uploader.Upload(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(wrapper.bucket),
 		Key:    aws.String(refMsg.S3Key),
 		Body:   bytes.NewReader(serialized),
 	})
@@ -130,7 +145,7 @@ func (client *SnsClientWrapper) PublishHeftyMessage(ctx context.Context, params 
 		params.MessageAttributes = orgMsgAttr
 	}()
 
-	out, err := client.Publish(ctx, params, optFns...)
+	out, err := wrapper.Publish(ctx, params, optFns...)
 	if err != nil {
 		return out, err
 	}

--- a/sqs.go
+++ b/sqs.go
@@ -61,9 +61,7 @@ func NewSqsClientWrapper(sqsClient *sqs.Client, s3Client *s3.Client, bucketName 
 			return nil, err
 		}
 	}
-	if wrapperOptions.alwaysSendToS3 != nil {
-		wrapper.alwaysSendToS3 = *wrapperOptions.alwaysSendToS3
-	}
+	wrapper.alwaysSendToS3 = wrapperOptions.alwaysSendToS3
 
 	return wrapper, nil
 }

--- a/sqs.go
+++ b/sqs.go
@@ -227,19 +227,11 @@ func (wrapper *SqsClientWrapper) ReceiveHeftyMessage(ctx context.Context, params
 }
 
 func addErrorToSqsMessage(msg *types.Message, refMsg *messages.ReferenceMsg, err error) {
-	type errMsg struct {
-		Error        string                 `json:"error"`
-		ReferenceMsg *messages.ReferenceMsg `json:"reference_msg"`
-	}
+	errMsg := messages.NewErrorMsg(err, refMsg)
 
-	e := &errMsg{
-		Error:        err.Error(),
-		ReferenceMsg: refMsg,
-	}
+	jsonErrMsg, _ := json.MarshalIndent(errMsg, "", "\t")
 
-	jErr, _ := json.MarshalIndent(e, "", "\t")
-
-	msg.Body = aws.String(string(jErr))
+	msg.Body = aws.String(string(jsonErrMsg))
 	msg.MD5OfBody = nil
 	msg.MD5OfMessageAttributes = nil
 }

--- a/sqs.go
+++ b/sqs.go
@@ -23,17 +23,18 @@ const (
 
 type SqsClientWrapper struct {
 	sqs.Client
-	bucket     string
-	s3Client   *s3.Client
-	uploader   *s3manager.Uploader
-	downloader *s3manager.Downloader
+	bucket         string
+	s3Client       *s3.Client
+	uploader       *s3manager.Uploader
+	downloader     *s3manager.Downloader
+	alwaysSendToS3 bool
 }
 
 // NewSqsClientWrapper will create a new Hefty SQS client wrapper using an existing AWS SQS client and AWS S3 client.
 // This Hefty SQS client wrapper will save large messages greater than MaxSqsSnsMessageLengthBytes to AWS S3 in the
 // bucket that is specified via `bucketName`. The S3 client should have the ability of reading and writing to this bucket.
 // This function will also check if the bucket exists and is accessible.
-func NewSqsClientWrapper(sqsClient *sqs.Client, s3Client *s3.Client, bucketName string) (*SqsClientWrapper, error) {
+func NewSqsClientWrapper(sqsClient *sqs.Client, s3Client *s3.Client, bucketName string, opts ...Option) (*SqsClientWrapper, error) {
 	// check if bucket exits
 	if ok, err := utils.BucketExists(s3Client, bucketName); !ok {
 		if err != nil {
@@ -43,13 +44,28 @@ func NewSqsClientWrapper(sqsClient *sqs.Client, s3Client *s3.Client, bucketName 
 		return nil, fmt.Errorf("bucket %s does not exist or is not accessible", bucketName)
 	}
 
-	return &SqsClientWrapper{
+	// create new wrapper
+	wrapper := &SqsClientWrapper{
 		Client:     *sqsClient,
 		bucket:     bucketName,
 		s3Client:   s3Client,
 		uploader:   s3manager.NewUploader(s3Client),
 		downloader: s3manager.NewDownloader(s3Client),
-	}, nil
+	}
+
+	// process available options
+	var wrapperOptions options
+	for _, opt := range opts {
+		err := opt(&wrapperOptions)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if wrapperOptions.alwaysSendToS3 != nil {
+		wrapper.alwaysSendToS3 = *wrapperOptions.alwaysSendToS3
+	}
+
+	return wrapper, nil
 }
 
 // SendHeftyMessage will calculate the messages size from `params` and determine if the MaxSqsSnsMessageLengthBytes is exceeded.
@@ -60,13 +76,13 @@ func NewSqsClientWrapper(sqsClient *sqs.Client, s3Client *s3.Client, bucketName 
 // including bucket name, S3 key, region, and md5 digests.
 //
 // Note that this function's signature matches that of the AWS SQS SDK's SendMessage function.
-func (client *SqsClientWrapper) SendHeftyMessage(ctx context.Context, params *sqs.SendMessageInput, optFns ...func(*sqs.Options)) (*sqs.SendMessageOutput, error) {
+func (wrapper *SqsClientWrapper) SendHeftyMessage(ctx context.Context, params *sqs.SendMessageInput, optFns ...func(*sqs.Options)) (*sqs.SendMessageOutput, error) {
 	// input validation; if invalid input let AWS SDK handle it
 	if params == nil ||
 		params.MessageBody == nil ||
 		len(*params.MessageBody) == 0 {
 
-		return client.SendMessage(ctx, params, optFns...)
+		return wrapper.SendMessage(ctx, params, optFns...)
 	}
 
 	// normalize message attributes
@@ -79,8 +95,8 @@ func (client *SqsClientWrapper) SendHeftyMessage(ctx context.Context, params *sq
 	}
 
 	// validate message size
-	if msgSize <= MaxAwsMessageLengthBytes {
-		return client.SendMessage(ctx, params, optFns...)
+	if !wrapper.alwaysSendToS3 && msgSize <= MaxAwsMessageLengthBytes {
+		return wrapper.SendMessage(ctx, params, optFns...)
 	} else if msgSize > MaxHeftyMessageLengthBytes {
 		return nil, fmt.Errorf("message size of %d bytes greater than allowed message size of %d bytes", msgSize, MaxHeftyMessageLengthBytes)
 	}
@@ -100,14 +116,14 @@ func (client *SqsClientWrapper) SendHeftyMessage(ctx context.Context, params *sq
 	}
 
 	// create reference message
-	refMsg, err := newSqsReferenceMessage(params.QueueUrl, client.bucket, client.Options().Region, msgBodyHash, msgAttrHash)
+	refMsg, err := newSqsReferenceMessage(params.QueueUrl, wrapper.bucket, wrapper.Options().Region, msgBodyHash, msgAttrHash)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create reference message from queueUrl. %v", err)
 	}
 
 	// upload hefty message to s3
-	_, err = client.uploader.Upload(ctx, &s3.PutObjectInput{
-		Bucket: aws.String(client.bucket),
+	_, err = wrapper.uploader.Upload(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(wrapper.bucket),
 		Key:    aws.String(refMsg.S3Key),
 		Body:   bytes.NewReader(serialized),
 	})
@@ -133,7 +149,7 @@ func (client *SqsClientWrapper) SendHeftyMessage(ctx context.Context, params *sq
 	}()
 
 	// send reference message to sqs
-	out, err := client.SendMessage(ctx, params, optFns...)
+	out, err := wrapper.SendMessage(ctx, params, optFns...)
 	if err != nil {
 		return out, err
 	}
@@ -146,8 +162,8 @@ func (client *SqsClientWrapper) SendHeftyMessage(ctx context.Context, params *sq
 }
 
 // SendHeftyMessageBatch is currently not supported and will use the underlying AWS SQS SDK's method `SendMessageBatch`
-func (client *SqsClientWrapper) SendHeftyMessageBatch(ctx context.Context, params *sqs.SendMessageBatchInput, optFns ...func(*sqs.Options)) (*sqs.SendMessageBatchOutput, error) {
-	return client.SendMessageBatch(ctx, params, optFns...)
+func (wrapper *SqsClientWrapper) SendHeftyMessageBatch(ctx context.Context, params *sqs.SendMessageBatchInput, optFns ...func(*sqs.Options)) (*sqs.SendMessageBatchOutput, error) {
+	return wrapper.SendMessageBatch(ctx, params, optFns...)
 }
 
 // ReceiveHeftyMessage will determine if a message received is a reference to a hefty message residing in AWS S3.
@@ -156,8 +172,8 @@ func (client *SqsClientWrapper) SendHeftyMessageBatch(ctx context.Context, param
 // important to use this function when `SendHeftyMessage` is used so that hefty messages can be downloaded from S3.
 //
 // Note that this function's signature matches that of the AWS SQS SDK's ReceiveMessage function.
-func (client *SqsClientWrapper) ReceiveHeftyMessage(ctx context.Context, params *sqs.ReceiveMessageInput, optFns ...func(*sqs.Options)) (*sqs.ReceiveMessageOutput, error) {
-	out, err := client.ReceiveMessage(ctx, params, optFns...)
+func (wrapper *SqsClientWrapper) ReceiveHeftyMessage(ctx context.Context, params *sqs.ReceiveMessageInput, optFns ...func(*sqs.Options)) (*sqs.ReceiveMessageOutput, error) {
+	out, err := wrapper.ReceiveMessage(ctx, params, optFns...)
 	if err != nil || out == nil {
 		return out, err
 	}
@@ -175,7 +191,7 @@ func (client *SqsClientWrapper) ReceiveHeftyMessage(ctx context.Context, params 
 
 		// make call to s3 to get message
 		buf := s3manager.NewWriteAtBuffer([]byte{})
-		_, err = client.downloader.Download(ctx, buf, &s3.GetObjectInput{
+		_, err = wrapper.downloader.Download(ctx, buf, &s3.GetObjectInput{
 			Bucket: &refMsg.S3Bucket,
 			Key:    &refMsg.S3Key,
 		})
@@ -212,11 +228,11 @@ func (client *SqsClientWrapper) ReceiveHeftyMessage(ctx context.Context, params 
 // if a hefty message resides in AWS S3 or not.
 //
 // Note that this function's signature matches that of the AWS SQS SDK's DeleteMessage function.
-func (client *SqsClientWrapper) DeleteHeftyMessage(ctx context.Context, params *sqs.DeleteMessageInput, optFns ...func(*sqs.Options)) (*sqs.DeleteMessageOutput, error) {
+func (wrapper *SqsClientWrapper) DeleteHeftyMessage(ctx context.Context, params *sqs.DeleteMessageInput, optFns ...func(*sqs.Options)) (*sqs.DeleteMessageOutput, error) {
 	const expectedHeftyReceiptHandleTokenCount = 4
 
 	if params.ReceiptHandle == nil {
-		return client.DeleteMessage(ctx, params, optFns...)
+		return wrapper.DeleteMessage(ctx, params, optFns...)
 	}
 
 	// decode receipt handle
@@ -228,7 +244,7 @@ func (client *SqsClientWrapper) DeleteHeftyMessage(ctx context.Context, params *
 
 	// check if decoded receipt handle is for a hefty message
 	if !strings.HasPrefix(decodedStr, receiptHandlePrefix) {
-		return client.DeleteMessage(ctx, params, optFns...)
+		return wrapper.DeleteMessage(ctx, params, optFns...)
 	}
 
 	// get tokens from receipt handle
@@ -239,7 +255,7 @@ func (client *SqsClientWrapper) DeleteHeftyMessage(ctx context.Context, params *
 
 	// delete hefty message from s3
 	receiptHandle, s3Bucket, s3Key := tokens[1], tokens[2], tokens[3]
-	_, err = client.s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
+	_, err = wrapper.s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: &s3Bucket,
 		Key:    &s3Key,
 	})
@@ -250,7 +266,7 @@ func (client *SqsClientWrapper) DeleteHeftyMessage(ctx context.Context, params *
 	// replace receipt handle with real one to delete sqs message
 	params.ReceiptHandle = &receiptHandle
 
-	return client.DeleteMessage(ctx, params, optFns...)
+	return wrapper.DeleteMessage(ctx, params, optFns...)
 }
 
 // Example queueUrl: https://sqs.us-west-2.amazonaws.com/765908583888/MyTestQueue

--- a/tests/hefty_client_test.go
+++ b/tests/hefty_client_test.go
@@ -186,13 +186,25 @@ var _ = Describe("Hefty Client Wrapper", func() {
 	}
 
 	When("When sending a message to AWS SQS with the Hefty client wrapper", func() {
-		Context("and the message is at, but not over the Hefty message size limit", Ordered, func() {
-			var queueUrl *string
-			var msg *string
-			var input *sqs.SendMessageInput
-			var sqsMsgAttr map[string]sqsTypes.MessageAttributeValue
-			var res *sqs.ReceiveMessageOutput
+		var queueUrl *string
+		var msg *string
+		var input *sqs.SendMessageInput
+		var sqsMsgAttr map[string]sqsTypes.MessageAttributeValue
+		var requestedAttr []string
+		var res *sqs.ReceiveMessageOutput
 
+		JustBeforeEach(OncePerOrdered, func() {
+			// send message to queue
+			input = SendSqsMessage(*queueUrl, *msg, sqsMsgAttr)
+
+			// receive message from queue
+			res = ReceiveSqsMessage(*queueUrl, requestedAttr)
+
+			// delete message from queue
+			DeleteHeftyMessage(*queueUrl, *res.Messages[0].ReceiptHandle)
+		})
+
+		Context("and the message is at, but not over the Hefty message size limit", Ordered, func() {
 			BeforeAll(func() {
 				// create queue
 				queueUrl = CreateSqsQueue()
@@ -201,17 +213,7 @@ var _ = Describe("Hefty Client Wrapper", func() {
 				var msgAttr map[string]messages.MessageAttributeValue
 				msg, msgAttr = testutils.GetMaxHeftyMsgBodyAndAttr()
 				sqsMsgAttr = messages.MapToSqsMessageAttributeValues(msgAttr)
-				requestedAttr := []string{"test03", "test05"}
-
-				// send message to queue
-				input = SendSqsMessage(*queueUrl, *msg, sqsMsgAttr)
-
-				// receive message from queue
-				res = ReceiveSqsMessage(*queueUrl, requestedAttr)
-			})
-
-			AfterAll(func() {
-				DeleteHeftyMessage(*queueUrl, *res.Messages[0].ReceiptHandle)
+				requestedAttr = []string{"test03", "test05"}
 			})
 
 			It("and the message body and message attributes sent is not overwritten", func() {
@@ -229,12 +231,6 @@ var _ = Describe("Hefty Client Wrapper", func() {
 		})
 
 		Context("and the message is at but not over the AWS SQS size limit", Ordered, func() {
-			var queueUrl *string
-			var msg *string
-			var input *sqs.SendMessageInput
-			var sqsMsgAttr map[string]sqsTypes.MessageAttributeValue
-			var res *sqs.ReceiveMessageOutput
-
 			BeforeAll(func() {
 				// create queue
 				queueUrl = CreateSqsQueue()
@@ -243,17 +239,7 @@ var _ = Describe("Hefty Client Wrapper", func() {
 				var msgAttr map[string]messages.MessageAttributeValue
 				msg, msgAttr = testutils.GetMaxSqsMsgBodyAndAttr()
 				sqsMsgAttr = messages.MapToSqsMessageAttributeValues(msgAttr)
-				requestedAttr := []string{"test03", "test05"}
-
-				// send message to queue
-				input = SendSqsMessage(*queueUrl, *msg, sqsMsgAttr)
-
-				// receive message from queue
-				res = ReceiveSqsMessage(*queueUrl, requestedAttr)
-			})
-
-			AfterAll(func() {
-				DeleteHeftyMessage(*queueUrl, *res.Messages[0].ReceiptHandle)
+				requestedAttr = []string{"test03", "test05"}
 			})
 
 			It("and the message body and message attributes sent is not overwritten", func() {
@@ -272,10 +258,39 @@ var _ = Describe("Hefty Client Wrapper", func() {
 					HaveKey(("test05")),
 				))
 			})
+
+			Context("but the AlwaysSendToS3 option was set on the wrapper", Ordered, func() {
+				BeforeAll(func() {
+					// override client wrapper
+					heftySqsClient, _ = hefty.NewSqsClientWrapper(sqsClient, s3Client, testBucket, hefty.AlwaysSendToS3())
+
+					// send message to queue
+					input = SendSqsMessage(*queueUrl, *msg, sqsMsgAttr)
+
+					// receive message from queue
+					res = ReceiveSqsMessage(*queueUrl, requestedAttr)
+
+					// delete message from queue
+					DeleteHeftyMessage(*queueUrl, *res.Messages[0].ReceiptHandle)
+				})
+
+				It("and even though 2 attributes were requested, we receive all of them", func() {
+					Expect(res.Messages[0].MessageAttributes).To(Equal(sqsMsgAttr))
+				})
+			})
 		})
 	})
 
 	When("When sending a message to AWS SNS with the Hefty client", func() {
+		var msg *string
+		var queueUrl *string
+		var topicArn *string
+		var snsMsgAttr map[string]snsTypes.MessageAttributeValue
+		var sqsMsgAttr map[string]sqsTypes.MessageAttributeValue
+		var requestedAttr []string
+		var input *sns.PublishInput
+		var res *sqs.ReceiveMessageOutput
+
 		CreateSnsTopicAndSubscription := func(queueUrl *string) *string {
 			GinkgoHelper()
 			// create topic
@@ -351,37 +366,31 @@ var _ = Describe("Hefty Client Wrapper", func() {
 			return input
 		}
 
-		Context("and the message is at, but not over the Hefty message size limit", Ordered, func() {
-			var msg *string
-			var queueUrl *string
-			var snsMsgAttr map[string]snsTypes.MessageAttributeValue
-			var sqsMsgAttr map[string]sqsTypes.MessageAttributeValue
-			var input *sns.PublishInput
-			var res *sqs.ReceiveMessageOutput
+		JustBeforeEach(OncePerOrdered, func() {
+			// publish message to topic
+			input = PublishSnsMessage(topicArn, msg, snsMsgAttr)
 
+			// receive message from queue
+			res = ReceiveSqsMessage(*queueUrl, requestedAttr)
+
+			// delete message from queue
+			DeleteHeftyMessage(*queueUrl, *res.Messages[0].ReceiptHandle)
+		})
+
+		Context("and the message is at, but not over the Hefty message size limit", Ordered, func() {
 			BeforeAll(func() {
 				// create queue
 				queueUrl = CreateSqsQueue()
+
 				// create topic and subscription
-				topicArn := CreateSnsTopicAndSubscription(queueUrl)
+				topicArn = CreateSnsTopicAndSubscription(queueUrl)
 
 				// create message body and attributes
 				var msgAttr map[string]messages.MessageAttributeValue
 				msg, msgAttr = testutils.GetMaxHeftyMsgBodyAndAttr()
 				snsMsgAttr = messages.MapToSnsMessageAttributeValues(msgAttr)
 				sqsMsgAttr = messages.MapToSqsMessageAttributeValues(msgAttr)
-				requestedAttr := []string{"test03", "test05"}
-
-				// publish message to topic
-				input = PublishSnsMessage(topicArn, msg, snsMsgAttr)
-
-				// receive message from queue
-				res = ReceiveSqsMessage(*queueUrl, requestedAttr)
-
-			})
-
-			AfterAll(func() {
-				DeleteHeftyMessage(*queueUrl, *res.Messages[0].ReceiptHandle)
+				requestedAttr = []string{"test03", "test05"}
 			})
 
 			It("and the message body and message attributes sent is not overwritten", func() {
@@ -399,33 +408,18 @@ var _ = Describe("Hefty Client Wrapper", func() {
 		})
 
 		Context("and the message is at but not over the AWS SNS size limit", Ordered, func() {
-			var msg *string
-			var queueUrl *string
-			var snsMsgAttr map[string]snsTypes.MessageAttributeValue
-			var input *sns.PublishInput
-			var res *sqs.ReceiveMessageOutput
-
 			BeforeAll(func() {
 				// create queue
 				queueUrl = CreateSqsQueue()
 				// create topic and subscription
-				topicArn := CreateSnsTopicAndSubscription(queueUrl)
+				topicArn = CreateSnsTopicAndSubscription(queueUrl)
 
 				// create message body and attributes
 				var msgAttr map[string]messages.MessageAttributeValue
 				msg, msgAttr = testutils.GetMaxSnsMsgBodyAndAttr()
 				snsMsgAttr = messages.MapToSnsMessageAttributeValues(msgAttr)
-				requestedAttr := []string{"test03", "test05"}
-
-				// publish message to topic
-				input = PublishSnsMessage(topicArn, msg, snsMsgAttr)
-
-				// receive message from queue
-				res = ReceiveSqsMessage(*queueUrl, requestedAttr)
-			})
-
-			AfterAll(func() {
-				DeleteHeftyMessage(*queueUrl, *res.Messages[0].ReceiptHandle)
+				sqsMsgAttr = messages.MapToSqsMessageAttributeValues(msgAttr)
+				requestedAttr = []string{"test03", "test05"}
 			})
 
 			It("and the message body and message attributes sent is not overwritten", func() {
@@ -443,6 +437,26 @@ var _ = Describe("Hefty Client Wrapper", func() {
 					HaveKey("test03"),
 					HaveKey(("test05")),
 				))
+			})
+		})
+
+		Context("but the AlwaysSendToS3 option was set on the wrapper", Ordered, func() {
+			BeforeAll(func() {
+				// override client wrapper
+				heftySnsClient, _ = hefty.NewSnsClientWrapper(snsClient, s3Client, testBucket, hefty.AlwaysSendToS3())
+
+				// publish message to topic
+				input = PublishSnsMessage(topicArn, msg, snsMsgAttr)
+
+				// receive message from queue
+				res = ReceiveSqsMessage(*queueUrl, requestedAttr)
+
+				// delete message from queue
+				DeleteHeftyMessage(*queueUrl, *res.Messages[0].ReceiptHandle)
+			})
+
+			It("and even though 2 attributes were requested, we receive all of them", func() {
+				Expect(res.Messages[0].MessageAttributes).To(Equal(sqsMsgAttr))
 			})
 		})
 	})

--- a/utilities.go
+++ b/utilities.go
@@ -18,3 +18,19 @@ func ReferenceMsg(msgBody string) (*messages.ReferenceMsg, bool) {
 
 	return ret, true
 }
+
+// ErrorMsg determines if a message body is an error message and returns a struct holding the error and the reference message.
+// If a message is indeed an error, the error signifies a problem getting either the hefty message from AWS S3 or an error
+// deserializing the reference message.
+func ErrorMsg(msgBody string) (*messages.ErrorMsg, bool) {
+	if !messages.IsErrorMsg(msgBody) {
+		return nil, false
+	}
+
+	ret, err := messages.ToErrorMsg(msgBody)
+	if err != nil {
+		return nil, false
+	}
+
+	return ret, true
+}


### PR DESCRIPTION
- Add option to always send message to S3
- Populate message body with an error in ReceiveHeftyMessage if the S3 payload for a particular SQS message received, was not able to be retrieved. Continue to process other messages instead of returning an error from ReceiveHeftyMessage .